### PR TITLE
Feat: 토큰 인증 middleware 구현 + @

### DIFF
--- a/app/apis/ApplyAPI/model/model.py
+++ b/app/apis/ApplyAPI/model/model.py
@@ -54,4 +54,9 @@ class RecruitCreate(BaseModel):
     recruit_end_date: datetime = Field(..., description="리크루팅 종료 날짜")
     form_id: int = Field(..., description="연결할 폼 ID")
     club_id: int = Field(..., description="클럽 ID")
+
+class VoteSubmission(BaseModel):
+    recruit_id: int
+    submission_id: int
+    status: str
         

--- a/app/apis/ApplyAPI/repository/query.py
+++ b/app/apis/ApplyAPI/repository/query.py
@@ -81,12 +81,6 @@ SET result = %s
 WHERE id = %s;
 """
 
-CHECK_IF_EXECUTIVE = """
-SELECT 1
-FROM BELONGING
-WHERE member_id = %s AND club_id = %s AND role IN ('PRESIDENT', 'VICE_PRESIDENT', 'EXECUTIVE');
-"""
-
 UPDATE_ANNOUNCEMENT_STATUS = """
 UPDATE RECRUIT
 SET is_announced = TRUE
@@ -138,4 +132,10 @@ GROUP BY R.end_date
 INSERT_RECRUIT = """
 INSERT INTO RECRUIT (name, start_date, end_date, form_id, status)
 VALUES (%s, %s, %s, %s, 'OPEN');
+"""
+
+GET_CLUB_ID_FROM_RECRUIT = """
+SELECT club_id
+FROM RECRUIT
+WHERE id = %s
 """

--- a/app/apis/ApplyAPI/repository/repository.py
+++ b/app/apis/ApplyAPI/repository/repository.py
@@ -1,6 +1,6 @@
 from app.db import run_query
 from datetime import datetime
-from app.apis.ApplyAPI.repository.query import SEARCH_RECRUIT, INSERT_SUBMISSION, INSERT_ANSWER, GET_SUBMISSION_ID, SELECT_QUESTION_ANSWERS, SELECT_SUBMISSION_LIST, UPDATE_SUBMISSION_STATUS, GET_ADMISSION_LIST, GET_ADMISSION_RESULT, UPDATE_SUBMISSION_RESULT, CHECK_IF_EXECUTIVE, UPDATE_ANNOUNCEMENT_STATUS, UPDATE_RECRUIT_END_DATE, SELECT_RECRUIT_DETAIL, SELECT_RECRUIT_LIST, GET_RECRUIT_STATUS, INSERT_RECRUIT
+from app.apis.ApplyAPI.repository.query import SEARCH_RECRUIT, INSERT_SUBMISSION, INSERT_ANSWER, GET_SUBMISSION_ID, SELECT_QUESTION_ANSWERS, SELECT_SUBMISSION_LIST, UPDATE_SUBMISSION_STATUS, GET_ADMISSION_LIST, GET_ADMISSION_RESULT, UPDATE_SUBMISSION_RESULT, GET_CLUB_ID_FROM_RECRUIT, UPDATE_ANNOUNCEMENT_STATUS, UPDATE_RECRUIT_END_DATE, SELECT_RECRUIT_DETAIL, SELECT_RECRUIT_LIST, GET_RECRUIT_STATUS, INSERT_RECRUIT
 
 class ApplyRepository:
     @staticmethod
@@ -103,15 +103,12 @@ class ApplyRepository:
             raise Exception(f"Database error while updating submission result: {e}")
 
     @staticmethod
-    def check_member_role(member_id: int, club_id: int):
+    def get_club_id_from_recruit(recruit_id: int) -> int:
         """
-        member_id와 club_id를 기반으로 임원진 권한을 확인합니다.
+        recruit_id로 club_id를 조회합니다.
         """
-        try:
-            result = run_query(CHECK_IF_EXECUTIVE, (member_id, club_id))
-            return bool(result)  # 데이터가 존재하면 True
-        except Exception as e:
-            raise Exception(f"Database error while checking member role: {e}")
+        result = run_query(GET_CLUB_ID_FROM_RECRUIT, (recruit_id,))
+        return result[0]["club_id"] if result else None
 
     """
     @staticmethod

--- a/app/apis/ApplyAPI/service/apply_service.py
+++ b/app/apis/ApplyAPI/service/apply_service.py
@@ -1,6 +1,7 @@
 from app.apis.FormAPI.service.form_service import FormService
 # from app.apis.NotificationAPI.service.notification_service import NotificationService
 from app.apis.ApplyAPI.repository.repository import ApplyRepository
+from app.apis.MemberAPI.service.college_service import AjouService
 from datetime import datetime
 
 class ApplyService:
@@ -94,12 +95,18 @@ class ApplyService:
         return ApplyRepository.get_admission_result(submission_id)
     
     @staticmethod
-    def vote_submission_result(member_id: int, club_id: int, submission_id: int, status: str):
+    def vote_submission_result(member_id: int, recruit_id: int, submission_id: int, status: str):
         """
-        임원진 권한을 확인하고, 지원서 상태를 업데이트합니다.
+        recruit_id로 club_id를 찾아 역할을 확인하고 지원서 상태를 업데이트합니다.
         """
-        # 권한 확인
-        if not ApplyRepository.check_member_role(member_id, club_id):
+        # recruit_id를 통해 club_id 조회
+        club_id = ApplyRepository.get_club_id_from_recruit(recruit_id)
+        if not club_id:
+            raise ValueError("Invalid recruit_id. Club not found.")
+
+        # 역할 확인
+        role = AjouService.get_member_role(member_id, club_id)
+        if role == "MEMBER" or role is None:
             raise PermissionError("You do not have permission to vote.")
 
         # 지원서 상태 업데이트

--- a/app/apis/MemberAPI/repository/query.py
+++ b/app/apis/MemberAPI/repository/query.py
@@ -9,3 +9,9 @@ MEMBER_CREATE = "INSERT INTO member (name, email, major, grade) VALUES (%s, %s, 
 
 MEMBER_FINDBY_ID = "SELECT * FROM member WHERE id = %s"
 MEMBER_FINDBY_EMAIL = "SELECT * FROM member WHERE email = %s"
+
+FIND_MEMBER_ROLE = """
+SELECT role
+FROM BELONGING
+WHERE member_id = %s AND club_id = %s
+"""

--- a/app/apis/MemberAPI/repository/repository.py
+++ b/app/apis/MemberAPI/repository/repository.py
@@ -42,4 +42,11 @@ def create_member(user_info: Member.Member) -> Member.Member:
     user_info['id'] = member_id
     return user_info
 
+def find_member_role(member_id: int, club_id: int) -> str:
+    """
+    DB에서 member_id와 club_id로 역할(role)을 찾습니다.
+    """
+    result = DBQueryRunner.run_query(query.FIND_MEMBER_ROLE, (member_id, club_id))
+    return result[0]["role"] if result else None
+
     

--- a/app/apis/MemberAPI/service/college_service.py
+++ b/app/apis/MemberAPI/service/college_service.py
@@ -1,5 +1,6 @@
 import json
 import os
+from app.apis.MemberAPI.repository.repository import find_member_role
 
 DEPART_MAP = {}
 DEPARTMAP_FILEDIR = os.path.join(os.path.dirname(__file__), "../../../../", "data", "departmap.json")
@@ -10,6 +11,15 @@ except FileNotFoundError:
   pass
 
 class AjouService:
+  @staticmethod
+  def get_member_role(member_id: int, club_id: int) -> str:
+      """
+      특정 member_id와 club_id에 대한 역할(role)을 반환합니다.
+      """
+      role = find_member_role(member_id, club_id)
+      if not role:
+          raise PermissionError("Member is not associated with the club or has no role assigned.")
+      return role
 
   def get_univ_depart(major: str):
     try:
@@ -40,3 +50,5 @@ class AjouService:
       return "석사/박사수료"
     else:
       return "기타"
+  
+   

--- a/app/apis/TestAPI/router/router.py
+++ b/app/apis/TestAPI/router/router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter, Request
 
 from app.apis.TestAPI.service.test_service import TestService
-from app.common.response.formatter import success_response
+from app.common.response.formatter import success_response, error_response
 
 from app.config import settings
 
@@ -12,7 +12,7 @@ async def test(request: Request):
   result = TestService.get_result()
   return success_response(data=result)
 
-@router.get("/check-env/")
+@router.get("/test/check-env/")
 async def check_env():
     """
     환경 변수의 로드 상태를 확인하는 API
@@ -26,3 +26,14 @@ async def check_env():
         "PORT": settings.PORT,
         "PY_ENV": settings.PY_ENV,
     }
+
+@router.post("/test/generate-jwt/")
+async def generate_jwt(user_id: int, name: str, email: str):
+    """
+    JWT 생성 API
+    """
+    try:
+        token = TestService.generate_jwt(user_id=user_id, name=name, email=email)
+        return success_response(data={"jwt": token})
+    except Exception as e:
+        return error_response(error="JWT_GENERATION_ERROR", message=str(e))

--- a/app/apis/TestAPI/service/test_service.py
+++ b/app/apis/TestAPI/service/test_service.py
@@ -1,8 +1,23 @@
-from datetime import datetime
-
+import jwt
+from datetime import datetime, timedelta
+from app.config import settings
 from app.apis.TestAPI.repository import repository
 
 class TestService:
+  @staticmethod
+  def generate_jwt(user_id: int, name: str, email: str) -> str:
+      """
+      JWT 생성
+      """
+      payload = {
+          "sub": user_id,  # 사용자 ID
+          "name": name,  # 사용자 이름
+          "email": email,  # 사용자 이메일
+          "iat": datetime.utcnow(),  # 토큰 생성 시간
+          "exp": datetime.utcnow() + timedelta(hours=1)  # 만료 시간 (1시간 후)
+      }
+      token = jwt.encode(payload, settings.TOKEN_SECRET, algorithm=settings.TOKEN_ALGORITHM)
+      return token
   
   def get_result():
     """
@@ -16,3 +31,5 @@ class TestService:
       "count": len(data),
       "results": data
     }
+  
+  

--- a/app/main.py
+++ b/app/main.py
@@ -3,6 +3,8 @@ from app.config import settings
 
 from fastapi import FastAPI
 from app.middlewares.log import log_requests
+from app.middlewares.token_validator import JWTAuthMiddleware
+from app.schemas.openapi_schema import custom_openapi
 
 from app.apis.TestAPI.router import router as TestRouter
 from app.apis.MemberAPI.router import router as MemberRouter
@@ -16,6 +18,17 @@ app = FastAPI(
     version="0.1.0",  # API 버전
 )
 
+# OpenAPI 스키마 설정
+app.openapi = lambda: custom_openapi(app)
+
+# JWT 미들웨어 추가
+app.add_middleware(JWTAuthMiddleware)
+
+# 요청 및 응답 로깅 미들웨어 추가
+@app.middleware("http")
+async def log_middleware(request, call_next):
+    return await log_requests(request, call_next)
+
 # 라우터 등록
 app.include_router(TestRouter.router, prefix="/api/v0", tags=["Test"])
 app.include_router(MemberRouter.router, prefix="/api/v0", tags=["Member"])
@@ -28,10 +41,6 @@ app.include_router(FormRouter.router, prefix="/api/v0", tags=["Form"])
 # dev/newbiehwang ApplyAPI router 추가
 app.include_router(ApplyRouter.router, prefix="/api/v0", tags=["Apply"])
 
-# 미들웨어나 이벤트 핸들러 추가 가능
-@app.middleware("http")
-async def middleware_wrapper(request, call_next):
-    return await log_requests(request, call_next)
 
 # 애플리케이션 실행
 if __name__ == "__main__":

--- a/app/middlewares/log.py
+++ b/app/middlewares/log.py
@@ -1,32 +1,46 @@
-# app/middleware.py
+# app/middlewares/log.py
 import logging
 from fastapi import Request
 from time import time
 
-# 로깅 설정
+# 기본 로깅 설정
 logging.basicConfig(
     level=logging.INFO,
     format="%(asctime)s - %(levelname)s - %(message)s",
     handlers=[
-        logging.StreamHandler(),  # 콘솔 출력
-        logging.FileHandler("logs/server.log")  # 로그 파일 저장
-    ]
+        logging.StreamHandler(),
+        logging.FileHandler("logs/server.log", mode="a"),
+    ],
 )
+
+# 공통 로거 생성
+def get_logger(name: str):
+    """
+    이름을 기준으로 로거를 반환합니다.
+    """
+    logger = logging.getLogger(name)
+    if not logger.handlers:  # 핸들러 중복 방지
+        handler = logging.FileHandler(f"logs/{name}.log", mode="a")
+        formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s")
+        handler.setFormatter(formatter)
+        logger.addHandler(handler)
+    logger.setLevel(logging.INFO)
+    return logger
 
 async def log_requests(request: Request, call_next):
     """
-    요청/응답 정보를 로깅하는 미들웨어 함수.
+    요청 및 응답을 로깅하는 미들웨어.
     """
-    start_time = time()  # 요청 시작 시간 기록
-    
-    # 요청 정보 로그
-    logging.info(f"Incoming request: {request.method} {request.url}")
-    
-    # 요청 처리
-    response = await call_next(request)
-    
-    # 응답 시간 계산 및 로그 기록
+    start_time = time()
+    logger = get_logger("RequestLogger")
+    logger.info(f"Incoming request: {request.method} {request.url}")
+
+    try:
+        response = await call_next(request)
+    except Exception as e:
+        logger.error(f"Request failed: {request.method} {request.url} - {e}")
+        raise
+
     duration = time() - start_time
-    logging.info(f"Completed response: {response.status_code} ({duration:.2f}s)")
-    
+    logger.info(f"Completed response: {response.status_code} ({duration:.2f}s)")
     return response

--- a/app/middlewares/token_validator.py
+++ b/app/middlewares/token_validator.py
@@ -1,0 +1,42 @@
+from starlette.middleware.base import BaseHTTPMiddleware
+from fastapi import Request, HTTPException
+import jwt
+from app.config import settings
+from app.middlewares.log import get_logger
+
+class JWTAuthMiddleware(BaseHTTPMiddleware):
+    """
+    JWT 인증 미들웨어
+    """
+    async def dispatch(self, request: Request, call_next):
+        logger = get_logger("JWTAuthMiddleware")
+
+        # Swagger UI 및 OpenAPI 문서 요청, TestAPI 요청은 예외 처리
+        if (
+            request.url.path.startswith("/docs")
+            or request.url.path.startswith("/openapi.json")
+            or request.url.path.startswith("/api/v0/test")
+            or request.url.path.startswith("/api/v0/login")
+        ):
+            logger.info(f"Skipping JWT validation for path: {request.url.path}")
+            return await call_next(request)
+
+        # Authorization 헤더 확인
+        auth_header = request.headers.get("Authorization")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            logger.warning("Authorization header missing or invalid")
+            raise HTTPException(status_code=401, detail="Authorization header missing or invalid")
+        
+        token = auth_header.split(" ")[1]
+        try:
+            # JWT 토큰 검증
+            jwt.decode(token, settings.TOKEN_SECRET, algorithms=[settings.TOKEN_ALGORITHM])
+            logger.info("JWT token is valid")
+        except jwt.ExpiredSignatureError:
+            logger.warning("JWT token has expired")
+            raise HTTPException(status_code=401, detail="Token has expired")
+        except jwt.InvalidTokenError:
+            logger.warning("Invalid JWT token")
+            raise HTTPException(status_code=401, detail="Invalid token")
+
+        return await call_next(request)

--- a/app/schemas/openapi_schema.py
+++ b/app/schemas/openapi_schema.py
@@ -1,0 +1,34 @@
+from fastapi.openapi.utils import get_openapi
+
+def custom_openapi(app):
+    """
+    Customizes the OpenAPI schema to include Bearer authentication.
+    """
+    if app.openapi_schema:
+        return app.openapi_schema
+
+    # Generate base OpenAPI schema
+    openapi_schema = get_openapi(
+        title="Weave API",
+        version="0.1.0",
+        description="[Ajou Univ.] 2024-2 DB 팀 프로젝트 Backend",
+        routes=app.routes,
+    )
+
+    # Add BearerAuth security schema
+    openapi_schema["components"] = openapi_schema.get("components", {})
+    openapi_schema["components"]["securitySchemes"] = {
+        "BearerAuth": {
+            "type": "http",
+            "scheme": "bearer",
+            "bearerFormat": "JWT"
+        }
+    }
+
+    # Apply security globally to all endpoints
+    for path in openapi_schema["paths"].values():
+        for method in path.values():
+            method["security"] = [{"BearerAuth": []}]
+
+    app.openapi_schema = openapi_schema  # Cache the schema
+    return openapi_schema


### PR DESCRIPTION
## 주요 수정사항
- **JWT 인증 미들웨어 구현**
  - 모든 요청에 대해 `Authorization` 헤더를 검사하고, 유효한 JWT 토큰인지 검증하도록 설정.
  - `/docs`, `/openapi.json`, `/login`과 같은 특정 경로는 인증을 우회하도록 예외 처리 추가.
- **Swagger UI에 Bearer 인증 스키마 추가**
  - API 문서에서 `Authorize` 버튼을 통해 JWT 토큰을 입력하여 테스트 가능.
- **TestAPI의 JWT 생성 엔드포인트 추가**
  - `POST /api/v0/test/generate-jwt`에서 JWT 토큰을 생성 가능.
  - 입력값: `user_id`, `name`, `email`
  - 출력값: 생성된 JWT 토큰.
- **로깅 개선**
  - 인증 성공/실패 및 요청/응답 정보를 기록하도록 미들웨어에 로깅 기능 통합.

---

## 사용 방법

1. `.env` 파일에 `TOKEN_SECRET`과 `TOKEN_ALGORITHM` 값을 설정하세요.
2. Swagger UI에서 Bearer 토큰 입력 후 인증된 상태에서 API 호출 테스트 가능.
   - **JWT 입력 방법**
     - `Authorize` 버튼 클릭.
     - <생성된 JWT 토큰>` 형식으로 입력.
     - ex.)eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOjEsIm5hbWUiOiJUZXN0IFVzZXIiLCJlbWFpbCI...

### JWT 발급 방법
1. Swagger UI에서 **`POST /api/v0/test/generate-jwt`** 호출.
2. 다음과 같은 입력값을 JSON 형식으로 전달:
   ```json
   {
     "user_id": 1,
     "name": "Test User",
     "email": "test@example.com"
   }